### PR TITLE
Possible bug in *_available() functions

### DIFF
--- a/uart.c
+++ b/uart.c
@@ -740,7 +740,7 @@ Returns:  Integer number of bytes in the receive buffer
 **************************************************************************/
 int uart0_available(void)
 {
-	return (UART_RX0_BUFFER_MASK + UART_RxHead - UART_RxTail) % UART_RX0_BUFFER_MASK;
+	return (UART_RX0_BUFFER_SIZE + UART_RxHead - UART_RxTail) % UART_RX0_BUFFER_SIZE;
 } /* uart0_available */
 
 /*************************************************************************
@@ -970,7 +970,7 @@ Returns:  Integer number of bytes in the receive buffer
 **************************************************************************/
 int uart1_available(void)
 {
-	return (UART_RX1_BUFFER_MASK + UART1_RxHead - UART1_RxTail) % UART_RX1_BUFFER_MASK;
+	return (UART_RX1_BUFFER_SIZE + UART1_RxHead - UART1_RxTail) % UART_RX1_BUFFER_SIZE;
 } /* uart1_available */
 
 
@@ -1208,7 +1208,7 @@ Returns:  Integer number of bytes in the receive buffer
 **************************************************************************/
 int uart2_available(void)
 {
-	return (UART_RX2_BUFFER_MASK + UART2_RxHead - UART2_RxTail) % UART_RX2_BUFFER_MASK;
+	return (UART_RX2_BUFFER_SIZE + UART2_RxHead - UART2_RxTail) % UART_RX2_BUFFER_SIZE;
 } /* uart2_available */
 
 
@@ -1445,7 +1445,7 @@ Returns:  Integer number of bytes in the receive buffer
 **************************************************************************/
 int uart3_available(void)
 {
-	return (UART_RX3_BUFFER_MASK + UART3_RxHead - UART3_RxTail) % UART_RX3_BUFFER_MASK;
+	return (UART_RX3_BUFFER_SIZE + UART3_RxHead - UART3_RxTail) % UART_RX3_BUFFER_SIZE;
 } /* uart3_available */
 
 


### PR DESCRIPTION
I believe there's a bug in the available functions. Instead of the actual size of the buffer the mask (size-1) is used which is wrong. 

Let's say buffer size is 8, Tail is 0 and Head 7. There are 7 elements available.

With the current code: available = (7+7-0)%7 = 0
whereas if we use the size: available = (8+7-0)%8 = 7

There might be a more optimal way to do the same without the modulus...but it works.
