### PR TITLE
Fixed UART_BAUD_SELECT and UART_BAUD_SELECT_DOUBLE_SPEED.

### DIFF
--- a/uart.h
+++ b/uart.h
@@ -187,13 +187,13 @@ Date        Description
  *  @param  xtalCpu  system clock in Mhz, e.g. 4000000L for 4Mhz          
  *  @param  baudRate baudrate in bps, e.g. 1200, 2400, 9600     
  */
-#define UART_BAUD_SELECT(baudRate,xtalCpu) ((xtalCpu)/((baudRate)*16l)-1)
+#define UART_BAUD_SELECT(baudRate,xtalCpu) (((xtalCpu)+8UL*(baudRate))/(16UL*(baudRate))-1UL)
 
 /** @brief  UART Baudrate Expression for ATmega double speed mode
  *  @param  xtalCpu  system clock in Mhz, e.g. 4000000L for 4Mhz           
  *  @param  baudRate baudrate in bps, e.g. 1200, 2400, 9600     
  */
-#define UART_BAUD_SELECT_DOUBLE_SPEED(baudRate,xtalCpu) (((xtalCpu)/((baudRate)*8l)-1)|0x8000)
+#define UART_BAUD_SELECT_DOUBLE_SPEED(baudRate,xtalCpu) ((((xtalCpu)+4UL*(baudRate))/(8UL*(baudRate))-1)|0x8000)
 
 /* test if the size of the circular buffers fits into SRAM */
 


### PR DESCRIPTION
For some combinations of MHz and bps, the previous definitions produced values for UBRR which were off by 1, mainly because integer divisions truncate results.

This new definitions use equations taken from AVR Libc's `setbaud.h`, v1.8.1 (copyright 2007 Cliff Lawson and Carlos Lamas).

Fixes #7.
